### PR TITLE
Fix window load handler and HTML closing tag

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -11,3 +11,4 @@
     <h1 id="list-name">Trello Player Power-up Privacy</h1>
     <p>Trello Player Power-up does not collect any information, it works solely within Trello borders.</p>
 </body>
+</html>

--- a/trello-player-power-up-popup.js
+++ b/trello-player-power-up-popup.js
@@ -29,7 +29,7 @@ async function loadPlayer() {
   }
   catch (error) {
     console.error('Error fetching attachments:', error);
-    alert('Failed to load attachmentas. Please try again.');
+    alert('Failed to load attachments. Please try again.');
   }
 }
 
@@ -68,4 +68,4 @@ audioPlayer.addEventListener('ended', () => {
   }
 });
 
-window.onload = loadPlayer();
+window.addEventListener('load', loadPlayer);


### PR DESCRIPTION
## Summary
- prevent early execution of `loadPlayer` by attaching it with `addEventListener`
- fix typo in error alert
- add missing closing HTML tag in `privacy.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e524d92e483328395c4c012f83011