### PR TITLE
Fix WaveSurfer draw call

### DIFF
--- a/trello-player-power-up-popup.html
+++ b/trello-player-power-up-popup.html
@@ -17,7 +17,7 @@
     </div>
     
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
-    <script src="./wavesurfer/wavesurfer.min.js"></script>
+    <script src="./wavesurfer/wavesurfer.min.js?1"></script>
     <script src="./trello-player-power-up-popup.js?2"></script>
   </body>
 </html>

--- a/wavesurfer/wavesurfer.min.js
+++ b/wavesurfer/wavesurfer.min.js
@@ -11,6 +11,7 @@
     this.canvas.style.height = '80px';
     this.container.appendChild(this.canvas);
     this.ctx = this.canvas.getContext('2d');
+    this.buffer = null;
     this.audio.addEventListener('timeupdate', () => this._drawProgress());
     this.container.addEventListener('click', (e) => {
       const rect = this.canvas.getBoundingClientRect();
@@ -24,8 +25,16 @@
     this._draw();
     const ctx = new (w.AudioContext || w.webkitAudioContext)();
     fetch(url).then(r => r.arrayBuffer()).then(b => ctx.decodeAudioData(b)).then(buf => {
+      this.buffer = buf;
       this._drawWave(buf);
+      this._drawProgress();
     });
+  };
+  WaveSurfer.prototype._draw = function(){
+    if(this.buffer){
+      this._drawWave(this.buffer);
+      this._drawProgress();
+    }
   };
   WaveSurfer.prototype._drawWave = function(buffer){
     this.canvas.width = this.container.clientWidth;


### PR DESCRIPTION
## Summary
- implement missing `_draw` function in custom WaveSurfer shim
- store decoded buffer for redrawing and progress updates

## Testing
- `git diff --cached --name-only`

------
https://chatgpt.com/codex/tasks/task_e_685e7667375083329bf50a6648cca802