### PR TITLE
Delay Trello auth form until required

### DIFF
--- a/src/trello-power-up/trello-player-power-up-popup.html
+++ b/src/trello-power-up/trello-player-power-up-popup.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="./trello-player.css?18">
   </head>
   <body>
-    <div id="auth-form">
+    <div id="auth-form" class="hidden">
       <label>API Key <input id="apikey-input" type="text"></label>
       <button id="authorize-button" type="button">Authorize</button>
     </div>


### PR DESCRIPTION
## Summary
- hide the authorization form by default in the Power-Up popup
- rely on existing logic to reveal the form only when no valid token or API key is available

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e78751f71483328d190e8fadb06544