### PR TITLE
Display audio duration prefix for loaded attachments

### DIFF
--- a/src/trello-power-up/trello-player-power-up-popup.html
+++ b/src/trello-power-up/trello-player-power-up-popup.html
@@ -63,6 +63,6 @@
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
     <script src="https://unpkg.com/wavesurfer.js@7"></script>
     <script src="./trello-player-config.js?1"></script>
-    <script src="./trello-player-power-up-popup.js?46"></script>
+    <script src="./trello-player-power-up-popup.js?47"></script>
   </body>
 </html>

--- a/src/trello-power-up/trello-player-power-up-popup.js
+++ b/src/trello-power-up/trello-player-power-up-popup.js
@@ -424,11 +424,15 @@ async function loadPlayer(token, key) {
         const li = attachmentTemplate.content.firstElementChild.cloneNode(true);
         li.dataset.attachmentId = attachment.id;
         li.dataset.originalName = attachment.name;
-        updateAttachmentDurationDisplay(attachment.id);
+        const nameElement = li.querySelector('.attachment-name');
+        if (nameElement) {
+          nameElement.textContent = attachment.name;
+        }
         li.addEventListener('click', () => {
           loadAttachment(m4aAttachments.findIndex((att) => att.id === attachment.id));
         });
         attachmentsList.appendChild(li);
+        updateAttachmentDurationDisplay(attachment.id);
       });
     });
 


### PR DESCRIPTION
## Summary
- track audio metadata to capture durations for loaded attachments
- update attachment list entries to prefix the formatted duration while preserving original names
- bump the popup script cache buster so Trello loads the updated logic

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ed04d109b48332b9e3c01daabc445c