### PR TITLE
Add A|B repeat loop control and consolidate playback buttons

### DIFF
--- a/src/trello-power-up/privacy.html
+++ b/src/trello-power-up/privacy.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Trello Player</title>
     <link rel="icon" type="image/png" href="./trello-player-192.png">
-    <link rel="stylesheet" href="./trello-player.css?19">
+    <link rel="stylesheet" href="./trello-player.css?20">
 </head>
 <body>
     <h1 id="list-name">Trello Player Power-up Privacy</h1>

--- a/src/trello-power-up/trello-player-power-up-popup.html
+++ b/src/trello-power-up/trello-player-power-up-popup.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Audio Player for Trello Power-Up Popup</title>
-    <link rel="stylesheet" href="./trello-player.css?24">
+    <link rel="stylesheet" href="./trello-player.css?25">
   </head>
   <body>
     <div id="auth-form" class="hidden">
@@ -14,8 +14,8 @@
       <waveform-preview id="waveform-view"></waveform-preview>
       <div class="player-controls">
         <button class="circle-btn" id="prev-button" title="Previous">&#x23EE;&#xFE0E;</button> <!-- ⏮ &#x23EE; -->
-        <button class="circle-btn" id="play-button" title="Play">&#x25B6;&#xFE0E;</button> <!-- ▶ &#x25B6; -->
-        <button class="circle-btn" id="pause-button" title="Pause">&#x23F8;&#xFE0E;</button> <!-- ⏸ &#x23F8; -->
+        <button class="circle-btn" id="play-pause-button" title="Play">&#x25B6;&#xFE0E;</button> <!-- ▶ / ⏸ -->
+        <button class="circle-btn" id="ab-button" title="Set A|B repeat points">A|B</button>
         <button class="circle-btn" id="stop-button" title="Stop">&#x23F9;&#xFE0E;</button> <!-- ⏹ &#x23F9; -->
         <button class="circle-btn" id="next-button" title="Next">&#x23ED;&#xFE0E;</button> <!-- ⏭ &#x23ED; -->
       </div>
@@ -62,6 +62,6 @@
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
     <script src="https://unpkg.com/wavesurfer.js@7"></script>
     <script src="./trello-player-config.js?1"></script>
-    <script src="./trello-player-power-up-popup.js?53"></script>
+    <script src="./trello-player-power-up-popup.js?54"></script>
   </body>
 </html>

--- a/src/trello-power-up/trello-player-power-up.html
+++ b/src/trello-power-up/trello-player-power-up.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Audio Player for Trello Power-Up Connector</title>
-    <link rel="stylesheet" href="./trello-player.css?19">
+    <link rel="stylesheet" href="./trello-player.css?20">
   </head>
   <body>
     <p>This is the HTML connector for the Audio Player for Trello Power-Up. It will be loaded into a hidden iframe when it is enabled.</p>

--- a/src/trello-power-up/trello-player.css
+++ b/src/trello-power-up/trello-player.css
@@ -16,6 +16,8 @@ body {
     --spinner-accent: var(--link-color);
     --waveform-overlay-bg: rgba(0, 0, 0, 0.5);
     --waveform-overlay-text: var(--text-color);
+    --waveform-region-color: rgba(110, 170, 255, 0.3);
+    --waveform-region-handle-color: rgba(150, 190, 255, 0.75);
   }
   body {
     background-color: var(--bg-color);
@@ -40,6 +42,8 @@ body {
     --spinner-accent: var(--link-color);
     --waveform-overlay-bg: rgba(255, 255, 255, 0.85);
     --waveform-overlay-text: var(--text-color);
+    --waveform-region-color: rgba(80, 130, 200, 0.3);
+    --waveform-region-handle-color: rgba(80, 130, 200, 0.85);
   }
   body {
     background-color: var(--bg-color);
@@ -95,6 +99,15 @@ audio {
   cursor: pointer;
   transition: background-color 0.3s, color 0.3s, transform 0.1s;
 }
+.circle-btn.active {
+  background-color: var(--btn-hover-bg);
+  color: var(--btn-hover-text);
+}
+.circle-btn.pending {
+  background-color: var(--btn-bg);
+  background-color: color-mix(in srgb, var(--btn-hover-bg) 40%, transparent);
+  color: var(--btn-color);
+}
 @media (hover: hover) and (pointer: fine) {
   .circle-btn:hover {
     background-color: var(--btn-hover-bg);
@@ -144,6 +157,14 @@ audio {
   width: 100%;
   min-height: 80px;
   position: relative;
+}
+.waveform-canvas .ws-region {
+  background-color: var(--waveform-region-color) !important;
+  border: 1px solid var(--waveform-region-color);
+  border-color: color-mix(in srgb, var(--waveform-region-color) 80%, transparent);
+}
+.waveform-canvas .ws-region-handle {
+  background-color: var(--waveform-region-handle-color) !important;
 }
 .wrench {
   font-family: "Segoe UI Symbol", "Arial Unicode MS", "Noto Sans", sans-serif;


### PR DESCRIPTION
## Summary
- merge the play and pause controls into a single toggle and update the popup logic accordingly
- add an A|B repeat control with loop enforcement and waveform region visualization
- tint waveform regions and bump stylesheet version references

## Testing
- node --check src/trello-power-up/trello-player-power-up-popup.js

------
https://chatgpt.com/codex/tasks/task_e_68ee991b48588332a3649a0a2dee6647