### PR TITLE
Improve attachment list autoscroll behavior

### DIFF
--- a/src/trello-power-up/trello-player-power-up-popup.html
+++ b/src/trello-power-up/trello-player-power-up-popup.html
@@ -63,6 +63,6 @@
     <script src="https://unpkg.com/wavesurfer.js@7"></script>
     <script src="https://unpkg.com/wavesurfer.js@7/dist/plugins/regions.min.js"></script>
     <script src="./trello-player-config.js?1"></script>
-    <script src="./trello-player-power-up-popup.js?54"></script>
+    <script src="./trello-player-power-up-popup.js?55"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- center the active attachment in the list when advancing playback and follow previous selections
- reset playback to the first attachment once the final track finishes without auto-playing
- bump the popup script cache bust parameter

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ef3acf3c4c83329bdfa4dab99d1d18